### PR TITLE
We are not downloading results properly with pbench rum

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -311,6 +311,7 @@ else
 	if [ $? -ne 0  ]; then
 		exit_out "Failed: $TOOLS_BIN/execute_via_pbench --cmd_executing "$0" $arguments --test ${test_name_run} --spacing 11 --pbench_stats $to_pstats"
 	fi
+	exit 0
 fi
 
 


### PR DESCRIPTION
When running via pbench, do not process the data twice, it is causing us not to have the run info in the zip files.
So once the pbench execution is done, exit out right away.