### PR TITLE
Use python binary directly instead of using update-alternatives

### DIFF
--- a/.github/workflows/issue_tagging.yaml
+++ b/.github/workflows/issue_tagging.yaml
@@ -1,7 +1,7 @@
 name: Update Parent issue
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - review_requested
   pull_request_review:

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -139,8 +139,8 @@ pip3_install()
 	fi
 
 	$python_exec -m pip --version
-	if [ $? -ne 0 ]; then
-		if [ $install_pip -eq 1 ]; then
+	if [[ $? -ne 0 ]]; then
+			if [[ $install_pip -eq 1 ]]; then
 			$python_exec -m ensurepip || exit_out "Failed to install pip." 1
 		else
 			exit_out "Pip is not available, exiting out" 1
@@ -148,7 +148,7 @@ pip3_install()
 	fi
 
 	$python_exec -m pip install -q $1
-	if [ $? -ne 0 ]; then
+	if [[ $? -ne 0 ]]; then
 		exit_out "Pip not available for install of $1 failed." 1
 	fi
 }
@@ -315,13 +315,12 @@ if [ $to_pbench -eq 0 ]; then
 	mkdir python_results
 	
 	pyresults=python_results/pyperf_out_$(date "+%Y.%m.%d-%H.%M.%S")
-	pwd > /tmp/dave_debug
-	echo $python_exec -m pyperformance run --output  ${pyresults}.json >> /tmp/dave_debug
+
 	$python_exec -m pyperformance run --output  ${pyresults}.json
 	if [ $? -ne 0 ]; then
 		exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" 1
 	fi
-	echo $python_exec -m pyperf dump  ${pyresults}.json >> /tmp/dave_debug
+	
 	$python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results
 	if [ $? -ne 0 ]; then
 		echo "Failed: $python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results" 1

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -19,6 +19,7 @@ PATH="${PATH}:/usr/local/bin"
 export PATH
 python_pkgs=""
 python_exec=""
+PYTHON_VERSION=""
 PYPERF_VERSION="1.11.0"
 #
 # To make sure.
@@ -94,7 +95,7 @@ generate_csv_file()
 	res_count=0
 	value_sum=0
 
-  $TOOLS_BIN/test_header_info --front_matter --results_file "${1}.csv" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $PYPERF_VERSION --test_name $test_name_run
+  $TOOLS_BIN/test_header_info --front_matter --results_file "${1}.csv" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version "py${PYTHON_VERSION}_$PYPERF_VERSION" --test_name $test_name_run 
 
 	echo "Test:Avg:Unit" >> "${1}.csv"
 	while IFS= read -r line
@@ -271,7 +272,7 @@ done
 
 if [ $to_pbench -eq 0 ]; then
 	rm -rf pyperformance
-
+	PYTHON_VERSION=$(python3 --version | awk '{ print $2 }')
 	python3 -m pip install pyperformance==$PYPERF_VERSION
 	if [ $? -ne 0 ]; then
 		exit_out "python3 -m pip install pyperformance==$PYPERF_VERSION: failed" 1


### PR DESCRIPTION
# Description
This PR updates the script to use the python binary directly instead of going through `update-alternatives`.  This is useful since the script will not touch what the default python interpreter is on a system.

As a result, we may need to get pip through the `ensurepip` module, since sometimes pip is not packaged for a python version (usually for RHEL-based OS's only the `python3` package has support for installing pip via the package manager), this PR adds a way for pip to be installed via `ensurepip` (disabled by default).

# Before/After Comparison
## Before
If an alternative python intepreter is needed, we would use `update-alternatives` so it would become the system's default interpreter.

## After
A python binary would be specified and used directly.

# Clerical Stuff
This closes #25 and will fix #21 .

Relates to JIRA: RPOPC-250
Relates to JIRA: RPOPC-251
