### PR TITLE
Convert to using python binary directly instead of alternatives

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -288,24 +288,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ $to_pbench -eq 0 ]; then
-	rm -rf pyperformance
 	PYTHON_VERSION=$(python3 --version | awk '{ print $2 }')
-	pip3_install "pyperformance==$PYPERF_VERSION"
-	cd pyperformance
 	if [[ ${python_pkgs} != "" ]]; then
 		pkg_list=`echo $python_pkgs | sed "s/,/ /g"`
 		test_tools/package_install --packages "$python_pkgs" --no_packages $to_no_pkg_install
 	fi
-	if [[ $python_exec != "" ]]; then
-		if [[ ! -f $python_exec ]]; then
-			exit_out "Error: Designated python executable, $python_exec, not present"
-		fi
-		#
-		# Remove the existing (if any) default python.
-		#
-		alternatives --remove-all python
- 		alternatives --install /usr/bin/python python $python_exec 1
+	if ! command -v $python_exec; then
+		exit_out "Error: Designated python executable, $python_exec, not present"
 	fi
+	pip3_install "pyperformance==$PYPERF_VERSION"
 	pip3_install psutil
 	pip3_install packaging
 	pip3_install pyparsing

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -18,7 +18,8 @@
 PATH="${PATH}:/usr/local/bin"
 export PATH
 python_pkgs=""
-python_exec=""
+python_exec="python3"
+install_pip=0
 PYTHON_VERSION=""
 PYPERF_VERSION="1.11.0"
 #
@@ -233,11 +234,12 @@ source test_tools/general_setup "$@"
 ARGUMENT_LIST=(
 	"pyperf_version"
 	"python_exec"
-        "python_pkgs"
+	"python_pkgs"
 )
 
 NO_ARGUMENTS=(
-        "usage"
+	"usage"
+	"install_pip"
 )
 
 # read arguments
@@ -265,6 +267,10 @@ while [[ $# -gt 0 ]]; do
 			python_pkgs=$2
 			shift 2
 		;;
+		--install_pip)
+			install_pip=1
+			shift 1
+		;;
 		--usage)
 			usage $0
 		;;
@@ -284,10 +290,7 @@ done
 if [ $to_pbench -eq 0 ]; then
 	rm -rf pyperformance
 	PYTHON_VERSION=$(python3 --version | awk '{ print $2 }')
-	python3 -m pip install pyperformance==$PYPERF_VERSION
-	if [ $? -ne 0 ]; then
-		exit_out "python3 -m pip install pyperformance==$PYPERF_VERSION: failed" 1
-	fi
+	pip3_install "pyperformance==$PYPERF_VERSION"
 	cd pyperformance
 	if [[ ${python_pkgs} != "" ]]; then
 		pkg_list=`echo $python_pkgs | sed "s/,/ /g"`

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -132,11 +132,22 @@ generate_csv_file()
 
 pip3_install()
 {
-	if [ $to_no_pkg_install -eq 0 ]; then
-		pip3 -q install $1
-		if [ $? -ne 0 ]; then
-			exit_out "pip3 install of $1 failed." 1
+	if [ $to_no_pkg_install -eq 1 ]; then
+		return
+	fi
+
+	$python_exec -m pip --version
+	if [[ $? -ne 0 ]]; then
+			if [[ $install_pip -eq 1 ]]; then
+			$python_exec -m ensurepip || exit_out "Failed to install pip." 1
+		else
+			exit_out "Pip is not available, exiting out" 1
 		fi
+	fi
+
+	$python_exec -m pip install -q $1
+	if [[ $? -ne 0 ]]; then
+		exit_out "Pip not available for install of $1 failed." 1
 	fi
 }
 #
@@ -303,14 +314,13 @@ if [ $to_pbench -eq 0 ]; then
 	mkdir python_results
 	
 	pyresults=python_results/pyperf_out_$(date "+%Y.%m.%d-%H.%M.%S")
-	pwd > /tmp/dave_debug
-	echo python3 -m pyperformance run --output  ${pyresults}.json >> /tmp/dave_debug
-	python3 -m pyperformance run --output  ${pyresults}.json
+
+	$python_exec -m pyperformance run --output  ${pyresults}.json
 	if [ $? -ne 0 ]; then
 		exit_out "Failed: python3 -m pyperformance run --output  ${pyresults}.json" 1
 	fi
-	echo python3 -m pyperf dump  ${pyresults}.json >> /tmp/dave_debug
-	python3 -m pyperf dump  ${pyresults}.json > ${pyresults}.results
+	
+	$python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results
 	if [ $? -ne 0 ]; then
 		echo "Failed: python3 -m pyperf dump  ${pyresults}.json > ${pyresults}.results" 1
 		echo Failed > test_results_report

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -288,7 +288,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ $to_pbench -eq 0 ]; then
-	PYTHON_VERSION=$(python3 --version | awk '{ print $2 }')
+	PYTHON_VERSION=$($python_exec --version | awk '{ print $2 }')
 	if [[ ${python_pkgs} != "" ]]; then
 		pkg_list=`echo $python_pkgs | sed "s/,/ /g"`
 		test_tools/package_install --packages "$python_pkgs" --no_packages $to_no_pkg_install
@@ -311,12 +311,12 @@ if [ $to_pbench -eq 0 ]; then
 
 	$python_exec -m pyperformance run --output  ${pyresults}.json
 	if [ $? -ne 0 ]; then
-		exit_out "Failed: python3 -m pyperformance run --output  ${pyresults}.json" 1
+		exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" 1
 	fi
 	
 	$python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results
 	if [ $? -ne 0 ]; then
-		echo "Failed: python3 -m pyperf dump  ${pyresults}.json > ${pyresults}.results" 1
+		echo "Failed: $python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results" 1
 		echo Failed > test_results_report
 	else
 		echo Ran > test_results_report


### PR DESCRIPTION
# Description
This PR updates the script to use the python binary directly instead of going through `update-alternatives`.  This is useful since the script will not touch what the default python interpreter is on a system.

As a result, we may need to get pip through the `ensurepip` module, since sometimes pip is not packaged for a python version (usually for RHEL-based OS's only the `python3` package has support for installing pip via the package manager), this PR adds a way for pip to be installed via `ensurepip` (disabled by default).

# Before/After Comparison
## Before
If an alternative python interpreter is needed, we would use `update-alternatives` so it would become the system's default interpreter.

## After
A python binary would be specified and used directly.

# Clerical Stuff
This closes #25 and will fix #21 .

Relates to JIRA: RPOPC-250
Relates to JIRA: RPOPC-251
