### PR TITLE
Remove pbench and Add PCP

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -28,6 +28,12 @@ copy_dirs=""
 #
 exit_out()
 {
+	if [[ $to_use_pcp -eq 1 ]]; then
+		stop_pcp_subset
+		stop_pcp
+		shutdown_pcp
+	fi
+
 	echo $1
 	exit $2
 }
@@ -347,6 +353,7 @@ generate_csv_file ${pyresults}
 
 if [[ $to_use_pcp -eq 1 ]]; then
 	stop_pcp_subset
+	stop_pcp
 	shutdown_pcp
 fi
 


### PR DESCRIPTION
# Description
This PR removes Pbench support since it is no longer supported by test-tools and Zathras as a whole, and introduces PCP archive recording to replace some of pbench's system metrics.

Additionally all test results are reported within the PCP archive under openmetrics.workload.pyperf_$TESTNAME

# Before/After Comparison
## Before
Pbench is present, but likely broken due to deprecation.

## After
Pbench is removed, and PCP is gathering system metrics.

# Clerical Stuff
this closes #49 and closes #50 
Relates to JIRA: RPOPC-620
Relates to JIRA: RPOPC-619
