### PR TITLE
Verify Results

### DIFF
--- a/pyperf.json
+++ b/pyperf.json
@@ -18,6 +18,15 @@
             "perf",
             "wget"
         ],
+        "fedora": [
+            "bc",
+            "git",
+            "zip",
+            "unzip",
+            "numactl",
+            "perf",
+            "wget"
+        ],
         "ubuntu": [
             "bc",
             "git",

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -367,8 +367,8 @@ fi
 
 generate_csv_file ${pyresults}
 
-$TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${pyresults}.json --output_file ${pyresults}.json
-$TOOLS_BIN/verify_results $to_verify_flags --file ${pyresults}.json --schema_file $to_script_dir/../result_schema.py
+$TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${pyresults}.csv --output_file ${pyresults}_validate.json
+$TOOLS_BIN/verify_results $to_verify_flags --file ${pyresults}_validate.json --schema_file $to_script_dir/../result_schema.py
 
 if [[ $to_use_pcp -eq 1 ]]; then
 	stop_pcp_subset

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -353,9 +353,6 @@ fi
 
 $python_exec -m pyperformance run --output  ${pyresults}.json
 
-$TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${pyresults}.json --output_file ${pyresults}.json
-$TOOLS_BIN/verify_results $to_verify_flags --file ${pyresults}.json --schema_file $to_script_dir/../result_schema.py
-
 if [ $? -ne 0 ]; then
 	exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" 1
 fi
@@ -369,6 +366,9 @@ else
 fi
 
 generate_csv_file ${pyresults}
+
+$TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${pyresults}.json --output_file ${pyresults}.json
+$TOOLS_BIN/verify_results $to_verify_flags --file ${pyresults}.json --schema_file $to_script_dir/../result_schema.py
 
 if [[ $to_use_pcp -eq 1 ]]; then
 	stop_pcp_subset

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -368,7 +368,7 @@ fi
 generate_csv_file ${pyresults}
 
 $TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${pyresults}.csv --output_file ${pyresults}_validate.json
-$TOOLS_BIN/verify_results $to_verify_flags --file ${pyresults}_validate.json --schema_file $to_script_dir/../result_schema.py
+$TOOLS_BIN/verify_results $to_verify_flags --file ${pyresults}_validate.json --schema_file $to_script_dir/../result_schema.py --class_name PyperfResult
 
 if [[ $to_use_pcp -eq 1 ]]; then
 	stop_pcp_subset

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -357,9 +357,9 @@ if [ $? -ne 0 ]; then
 	exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" 1
 fi
 
-$python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results
+$python_exec -m pyperf dump  --quiet ${pyresults}.json > ${pyresults}.results
 if [ $? -ne 0 ]; then
-	echo "Failed: $python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results" 1
+	echo "Failed: $python_exec -m pyperf dump --quiet  ${pyresults}.json > ${pyresults}.results" 1
 	echo Failed > test_results_report
 else
 	echo Ran > test_results_report

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -352,6 +352,10 @@ if [[ $to_use_pcp -eq 1 ]]; then
 fi
 
 $python_exec -m pyperformance run --output  ${pyresults}.json
+
+$TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${pyresults}.json --output_file ${pyresults}.json
+$TOOLS_BIN/verify_results $to_verify_flags --file ${pyresults}.json --schema_file $to_script_dir/../result_schema.py
+
 if [ $? -ne 0 ]; then
 	exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" 1
 fi

--- a/python_deps/python3.json
+++ b/python_deps/python3.json
@@ -10,6 +10,11 @@
             "python3-devel",
             "python3-pip"
         ],
+        "fedora": [
+            "python3",
+            "python3-devel",
+            "python3-pip"
+        ],
         "ubuntu": [
             "python3",
             "python3-dev",

--- a/result_schema.py
+++ b/result_schema.py
@@ -1,0 +1,13 @@
+from enum import Enum
+import pydantic
+
+class DurationUnit(str, Enum):
+	sec = "sec"
+	ms = "ms"
+	us = "us"
+	ns = "ns"
+
+class PyperfResult(pydantic.BaseModel):
+	Test: str = pydantic.Field(description="Name of the test that was ran")
+	Avg: float = pydantic.Field(description="Duration, unit is determined by duration_unit field", allow_inf_nan=False, gt=0)
+	Unit: DurationUnit = pydantic.Field(description="Unit of duration")


### PR DESCRIPTION
# Description
This PR adds the functionality for automatic checking of the resulting data after a run's conclusion.

Additionally it adds fedora as a supported OS, and fixes a bug where `pyperf dump <result json>` could output warning messages that mess with CSV creation.

# Before/After Comparison
## Before
Runs could contain invalid output and that could lead to problems later down the pipeline

## After
Runs verify the results outputted, and error in the case a problem is found.

# Clerical Stuff
This closes #43 
Relates to JIRA: RPOPC-427
