### PR TITLE
Add `--benchmarks` flag to limit what benchmarks pyperformance runs

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -23,6 +23,7 @@ install_pip=0
 PYTHON_VERSION=""
 PYPERF_VERSION="1.11.0"
 copy_dirs=""
+benchmarks="all"
 
 base_dir=$(dirname $(realpath $0))
 #
@@ -46,6 +47,7 @@ usage()
 	echo "--pyperf_version <version number>: Version of pyperf to run, default is $PYPERF_VERSION."
 	echo "--python_exec_path: Python to set via alternatives"
 	echo "--python_pkgs: comma seprated list of python packages to install"
+	echo "--pyperf_benchmarks: Comma separated list of pyperformance benchmarks to run.  Default is to run all tests."
 	source test_tools/general_setup --usage
         exit 1
 }
@@ -255,6 +257,7 @@ ARGUMENT_LIST=(
 	"pyperf_version"
 	"python_exec"
 	"python_pkgs"
+	"pyperf_benchmarks"
 )
 
 NO_ARGUMENTS=(
@@ -290,6 +293,10 @@ while [[ $# -gt 0 ]]; do
 		--install_pip)
 			install_pip=1
 			shift 1
+		;;
+		--pyperf_benchmarks)
+			benchmarks=$2
+			shift 2
 		;;
 		--usage)
 			usage $0
@@ -351,7 +358,12 @@ if [[ $to_use_pcp -eq 1 ]]; then
 	copy_dirs="$pcp_dir"
 fi
 
-$python_exec -m pyperformance run --output  ${pyresults}.json
+pyperf_flags=""
+if [[ "$benchmarks" != "all" ]]; then
+	pyperf_flags="-b $benchmarks"
+fi
+
+$python_exec -m pyperformance run --output  ${pyresults}.json $pyperf_flags
 if [ $? -ne 0 ]; then
 	exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" 1
 fi

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -52,6 +52,26 @@ usage()
         exit 1
 }
 
+verify_benchmark_names()
+{
+	benchmark_file=$(mktemp pyperf_benchmarks.XXXXX)
+	$python_exec -m pyperformance list | head -n -2 | tail -n +2 | sed -e 's/- //g' > $benchmark_file
+	invalid_benchmarks=""
+	for benchmark in $(echo $benchmarks | tr ',' ' '); do
+		grep $benchmark $benchmark_file > /dev/null
+
+		if [[ $? -ne 0 ]]; then
+			invalid_benchmarks="$benchmark $invalid_benchmarks"
+		fi
+	done
+
+	rm -f $benchmark_file
+
+	if [[ -n "$invalid_benchmarks" ]]; then
+		exit_out "Error: Could not find the following benchmarks $invalid_benchmarks" 1
+	fi
+}
+
 install_tools()
 {
 	show_usage=0
@@ -223,7 +243,7 @@ ${curdir}/test_tools/gather_data ${curdir}
 if [ ! -f "/tmp/pyperf.out" ]; then
         command="${0} $@"
         echo $command
-        $command &> /tmp/pyperf.out
+        $command 2>&1 | tee /tmp/pyperf.out
 	rtc=$?
 	if [ -f /tmp/pyperf.out ]; then
 		echo =================================
@@ -360,6 +380,7 @@ fi
 
 pyperf_flags=""
 if [[ "$benchmarks" != "all" ]]; then
+	verify_benchmark_names
 	pyperf_flags="-b $benchmarks"
 fi
 


### PR DESCRIPTION
# Description
This PR adds the `--benchmarks` flag which takes a comma separated list of [pyperformance benchmark names](https://pyperformance.readthedocs.io/benchmarks.html#available-benchmarks).  This flag will only run the specified benchmarks.

The previous behavior of running all the benchmarks is the default, so any existing automation should not be impacted

# Before/After Comparison
## Before
The only behavior of this wrapper is to run all the pyperformance benchmarks.

## After
The default behavior of this wrapper is to run all the pyperformance benchmarks.

The user can use `--benchmarks <name1,name2,...>` to provide a list of benchmarks that they wish to run.  This is useful for development and for skipping benchmarks that may have a longer runtime.

# Clerical Stuff
This closes #54 

Relates to JIRA: RPOPC-756
