### PR TITLE
Enable RAG on relevant repos

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,6 @@
+[rag_arguments]
+enable_rag=true
+rag_repo_list= [
+    "redhat-performance/test_tools-wrappers",
+    "redhat-performance/pyperf-wrapper"
+]


### PR DESCRIPTION
### **User description**
# Description
Enables RAG parsing for Qodo on test_tools-wrappers and pyperf-wrapper to bring relevant context to the bot's reviews.

# Before/After Comparison
## Before
Qodo would only have the context of this repo, and will not know anything about the tools in the `test_tools-wrappers` repo.

## After
Qodo will have both this repo and `test_tools-wrappers` in it's context to perform code feedback.

# Clerical Stuff
This closes #64 
Relates to JIRA: RPOPC-830
___

### **PR Type**
Enhancement


___

### **Description**
- Added RAG configuration file for AI code review

- Enabled RAG parsing for two related repositories

- Configured context from `test_tools-wrappers` and `pyperf-wrapper` repos


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New .pr_agent.toml"] --> B["Enable RAG"]
  B --> C["Add test_tools-wrappers repo"]
  B --> D["Add pyperf-wrapper repo"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Configure RAG with external repository references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Created new configuration file for PR agent<br> <li> Enabled RAG (Retrieval-Augmented Generation) feature<br> <li> Added two external repositories to RAG context: <code>test_tools-wrappers</code> <br>and <code>pyperf-wrapper</code></ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-performance/pyperf-wrapper/pull/62/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

