### PR TITLE
Update how we get test_tools and be more specific on return codes.

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -445,6 +445,9 @@ fi
 end_time=$(retrieve_time_stamp)
 
 $python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results
+if [[ $?  -ne 0 ]]; then
+	exit_out "Error: $python_exec -m pyperf dump  ${pyresults}.json" $E_GENERAL
+fi
 
 generate_csv_file ${pyresults} ${start_time} ${end_time}
 

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -466,5 +466,5 @@ fi
 #
 # Process the data.
 #
-${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --results /tmp/pyperf.out  --test_name pyperf --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "python_results/*,test_results_report" $copy_dirs
+${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --results /tmp/pyperf.out  --test_name pyperf --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "python_results/*" $copy_dirs
 exit $rtc

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -53,7 +53,7 @@ usage()
 	echo "--python_exec_path: Python to set via alternatives"
 	echo "--python_pkgs: comma seprated list of python packages to install"
 	echo "--pyperf_benchmarks: Comma separated list of pyperformance benchmarks to run.  Default is to run all tests."
-	source test_tools/general_setup --usage
+	source $TOOLS_BIN/general_setup --usage
         exit $E_USAGE
 }
 

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -101,6 +101,40 @@ setup_pyperformance()
 	fi
 }
 
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 101
+                fi
+        fi
+}
+
 install_tools()
 {
 	show_usage=0
@@ -132,12 +166,10 @@ install_tools()
 	# Check to see if the test tools directory exists.  If it does, we do not need to
 	# clone the repo.
 	#
-	if [ ! -d "$TOOLS_BIN" ]; then
-		git clone $tools_git "$TOOLS_BIN"
-		if [ $? -ne 0 ]; then
-			exit_out "pulling git $tools_git failed." 1
-		fi
-	fi
+
+	attempt_tools_wget
+	attempt_tools_curl
+	attempt_tools_git
 
 	if [ $show_usage -eq 1 ]; then
 		usage $1

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -54,7 +54,7 @@ usage()
 	echo "--python_pkgs: comma seprated list of python packages to install"
 	echo "--pyperf_benchmarks: Comma separated list of pyperformance benchmarks to run.  Default is to run all tests."
 	source test_tools/general_setup --usage
-        exit 1
+        exit $E_USAGE
 }
 
 verify_benchmark_names()
@@ -73,7 +73,7 @@ verify_benchmark_names()
 	rm -f $benchmark_file
 
 	if [[ -n "$invalid_benchmarks" ]]; then
-		exit_out "Error: Could not find the following benchmarks $invalid_benchmarks" 1
+		exit_out "Error: Could not find the following benchmarks $invalid_benchmarks" $E_GENERAL
 	fi
 }
 
@@ -86,10 +86,10 @@ setup_pyperformance()
 	venv_path=$($python_exec -m pyperformance venv show | sed -e "s/Virtual environment path: //g" -e "s/ (already created)//" )
 
 	if [[ -z "$venv_path" ]]; then
-		exit_out "Error: Could not determine pyperformance venv path, exiting" 1
+		exit_out "Error: Could not determine pyperformance venv path, exiting" $E_GENERAL
 	fi
 	if [[ ! -x "$venv_path/bin/python3" ]]; then
-		exit_out "Error: Could not find interpreter at $venv_path/bin/python3, exiting" 1
+		exit_out "Error: Could not find interpreter at $venv_path/bin/python3, exiting" $E_GENERAL
 	fi
 
 	# Revert to setuptools v81.0.0 due to `pkg_resources` removal at v82.0.0
@@ -252,15 +252,15 @@ pip3_install()
 	$python_exec -m pip --version
 	if [[ $? -ne 0 ]]; then
 			if [[ $install_pip -eq 1 ]]; then
-			$python_exec -m ensurepip || exit_out "Failed to install pip." 1
+			$python_exec -m ensurepip || exit_out "Failed to install pip." $E_GENERAL
 		else
-			exit_out "Pip is not available, exiting out" 1
+			exit_out "Pip is not available, exiting out" $E_GENERAL
 		fi
 	fi
 
 	$python_exec -m pip install -q $1
 	if [[ $? -ne 0 ]]; then
-		exit_out "Pip not available for install of $1 failed." 1
+		exit_out "Pip not available for install of $1 failed." $E_GENERAL
 	fi
 }
 #
@@ -390,26 +390,26 @@ if [[ ${python_pkgs} != "" ]]; then
 	pkg_list="--packages `echo $python_pkgs | sed "s/,/ /g"`"
 fi
 if ! command -v $python_exec; then
-	exit_out "Error: Designated python executable, $python_exec, not present"
+	exit_out "Error: Designated python executable, $python_exec, not present" $E_GENERAL
 fi
 
 if [[  $to_no_pkg_install -eq 0 ]]; then
 	python_bin_name=$(basename $python_exec)
 	python_dep_file="$base_dir/../python_deps/$python_bin_name.json"
 	if [[ ! -f "$python_dep_file" ]]; then
-		exit_out "Unsupported python binary $python_bin_name, exiting" 1
+		exit_out "Unsupported python binary $python_bin_name, exiting" $E_GENERAL
 	fi
 
 	$TOOLS_BIN/package_tool --wrapper_config $python_dep_file
 
 	if [[ $? -ne 0 ]]; then
-		exit_out "Error installing needed python dependencies" 1
+		exit_out "Error installing needed python dependencies" $E_GENERAL
 	fi
 
 	$TOOLS_BIN/package_tool --wrapper_config $base_dir/../pyperf.json $pkg_list --pip_packages "pyperformance==$PYPERF_VERSION"
 
 	if [[ $? -ne 0 ]]; then
-		exit_out "Error installing system packages" 1
+		exit_out "Error installing system packages" $E_GENERAL
 	fi
 fi
 
@@ -440,17 +440,11 @@ setup_pyperformance
 start_time=$(retrieve_time_stamp)
 $python_exec -m pyperformance run --output  ${pyresults}.json $pyperf_flags
 if [ $? -ne 0 ]; then
-	exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" 1
+	exit_out "Failed: $python_exec -m pyperformance run --output  ${pyresults}.json" $E_GENERAL
 fi
 end_time=$(retrieve_time_stamp)
 
 $python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results
-if [ $? -ne 0 ]; then
-	echo "Failed: $python_exec -m pyperf dump  ${pyresults}.json > ${pyresults}.results" 1
-	echo Failed > test_results_report
-else
-	echo Ran > test_results_report
-fi
 
 generate_csv_file ${pyresults} ${start_time} ${end_time}
 


### PR DESCRIPTION
# Description
Uses error_codes found in test_tools/error_codes to provide more specific error indication.

# Before/After Comparison
Before: Returned a 0 or 1, making determination of having to rerun very course
After: Error codes are now bases on test_tools/error_codes, making it easier to limit when we do a rerun of the test.
Also, changed how we load in test_tools, we try curl, git, and wget, to avoid a failure due to the program not
being installed.

# Clerical Stuff
This closes #67 

Relates to JIRA: RPOPC-879

Testing done

Ran following scenario
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: pyperf_results
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "pyperf"
    host_config: "m5.xlarge"

Generated the following csv file
Test,Avg,Unit,Start_Date,End_Date
2to3,440.55,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
async_generators,543.88,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
async_tree_none,901.17,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
async_tree_cpu_io_mixed,1.23,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
async_tree_io,2.34,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
async_tree_memoization,1.23,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
asyncio_tcp,338.56,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
asyncio_tcp_ssl,2.91,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
asyncio_websockets,716.32,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
chameleon,13.39,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
chaos,155.55,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
comprehensions,36.63,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
bench_mp_pool,16.13,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
bench_thread_pool,1.58,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
coroutines,56.83,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
coverage,78.47,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
crypto_pyaes,157.17,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
dask,732.55,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
deepcopy,613.48,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
deepcopy_reduce,5.28,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
deepcopy_memo,75.53,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
deltablue,9.95,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
docutils,3.93,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
dulwich_log,99.45,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
fannkuch,683.33,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
float,167.18,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
create_gc_cycles,1.78,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
gc_traversal,3.86,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
generators,86.43,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
genshi_text,42.91,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
genshi_xml,85.81,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
go,354.10,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
hexiom,13.82,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
html5lib,114.23,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
json_dumps,18.00,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
json_loads,36.62,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
logging_format,12.49,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
logging_silent,272.30,ns,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
logging_simple,11.40,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
mako,23.41,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
mdp,3.75,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
meteor_contest,146.68,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
nbody,197.10,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
nqueens,136.17,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pathlib,24.25,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pickle,13.01,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pickle_dict,36.76,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pickle_list,5.88,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pickle_pure_python,613.73,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pidigits,230.02,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pprint_pformat,2.04,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
pyflate,944.85,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
python_startup,12.29,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
python_startup_no_site,7.71,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
raytrace,693.78,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
regex_compile,241.43,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
regex_dna,287.92,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
regex_effbot,4.34,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
regex_v8,32.71,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
richards,98.45,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
richards_super,118.42,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
scimark_fft,550.57,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
scimark_lu,225.72,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
scimark_monte_carlo,155.62,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
scimark_sor,282.68,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
scimark_sparse_mat_mult,7.28,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
spectral_norm,213.53,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sqlalchemy_declarative,217.13,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sqlalchemy_imperative,28.10,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sqlglot_normalize,178.22,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sqlglot_optimize,86.39,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sqlglot_parse,3.07,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sqlglot_transpile,3.55,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sqlite_synth,3.51,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sympy_expand,698.25,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sympy_integrate,32.31,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sympy_sum,242.22,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
sympy_str,425.12,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
telco,8.58,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
tomli_loads,3.93,sec,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
tornado_http,186.17,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
typing_runtime_protocols,686.43,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
unpack_sequence,95.92,ns,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
unpickle,17.30,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
unpickle_list,6.01,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
unpickle_pure_python,444.43,us,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
xml_etree_parse,210.67,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
xml_etree_iterparse,141.45,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
xml_etree_generate,128.22,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
xml_etree_process,102.67,ms,2026-03-16T12:04:52Z,2026-03-16T13:11:26Z
