### PR TITLE
Use package_tool in general_setup

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -400,13 +400,13 @@ if [[  $to_no_pkg_install -eq 0 ]]; then
 		exit_out "Unsupported python binary $python_bin_name, exiting" $E_GENERAL
 	fi
 
-	$TOOLS_BIN/package_tool --wrapper_config $python_dep_file
+	package_tool --wrapper_config $python_dep_file
 
 	if [[ $? -ne 0 ]]; then
 		exit_out "Error installing needed python dependencies" $E_GENERAL
 	fi
 
-	$TOOLS_BIN/package_tool --wrapper_config $base_dir/../pyperf.json $pkg_list --pip_packages "pyperformance==$PYPERF_VERSION"
+	package_tool --wrapper_config $base_dir/../pyperf.json $pkg_list --pip_packages "pyperformance==$PYPERF_VERSION"
 
 	if [[ $? -ne 0 ]]; then
 		exit_out "Error installing system packages" $E_GENERAL


### PR DESCRIPTION
# Description
Replacing ${TOOLS_BIN}/package_tool with package_tool so we use the wrapper in general_setup

# Before/After Comparison
Before: Calling package_tool script directly, possible impacting options passed
After: Using the wrapper around package_tools

# Clerical Stuff
This closes #69 

Relates to JIRA: RPOPC-894

Testing
Verified the wrapper still ran as expected.
CSV File generate
Test,Avg,Unit,Start_Date,End_Date
2to3,440.03,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
async_generators,508.68,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
async_tree_none,926.15,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
async_tree_cpu_io_mixed,1.27,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
async_tree_io,2.28,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
async_tree_memoization,1.09,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
asyncio_tcp,34.26,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
asyncio_tcp_ssl,2.91,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
asyncio_websockets,717.03,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
chameleon,13.27,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
chaos,154.67,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
comprehensions,36.63,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
bench_mp_pool,15.01,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
bench_thread_pool,1.54,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
coroutines,56.98,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
coverage,77.77,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
crypto_pyaes,156.47,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
dask,725.37,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
deepcopy,609.20,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
deepcopy_reduce,5.24,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
deepcopy_memo,75.58,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
deltablue,9.94,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
docutils,3.91,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
dulwich_log,97.63,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
fannkuch,679.72,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
float,170.03,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
create_gc_cycles,1.75,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
gc_traversal,3.84,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
generators,70.30,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
genshi_text,41.56,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
genshi_xml,82.83,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
go,351.62,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
hexiom,13.73,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
html5lib,113.02,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
json_dumps,17.80,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
json_loads,36.55,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
logging_format,11.90,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
logging_silent,272.13,ns,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
logging_simple,11.01,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
mako,23.49,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
mdp,3.76,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
meteor_contest,146.68,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
nbody,197.22,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
nqueens,136.53,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
pathlib,24.28,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
pickle,13.05,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
pickle_dict,36.78,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
pickle_list,5.88,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
pickle_pure_python,608.58,us,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
pidigits,230.80,ms,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
pprint_pformat,2.02,sec,2026-03-20T15:48:12Z,2026-03-20T16:54:25Z
