### PR TITLE
pyperf may not always return accurate run info

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -206,10 +206,9 @@ generate_csv_file()
 			let "reduce=$reduce+1"
 			if [[ $reduce -eq 2 ]]; then
 				if [[ $test_name != *"WARNING:"* ]]; then
-					# Cannot use convert_val directly since it does not support floating point output
-					results=$(echo "${value_sum}/${res_count}" | bc -l | cut -d'.' -f1 )
-					sec_results=$(echo "$results/1000000000" | bc -l)
-					printf "%s,%f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
+					results=$(echo "${value_sum}/${res_count}" | bc)
+					sec_results=$(${TOOLS_BIN}/convert_val --time_val --from_unit  ns --to_unit secs --value $results --float --no_unit)
+					printf "%s,%.9f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
 					
 					if [[ $to_use_pcp -eq 1 ]]; then
 						metric_name="pyperf_${test_name}"
@@ -228,19 +227,18 @@ generate_csv_file()
 		fi
 		value=`echo $line | cut -d' ' -f 4`
 		unit=`echo $line | cut -d' ' -f 5`
-		cnv_val=$($TOOLS_BIN/convert_val --time_val --from_unit  $unit --to_unit ns --value $value | sed "s/ns//g")
+		cnv_val=$($TOOLS_BIN/convert_val --time_val --from_unit  $unit --to_unit ns --value $value --no_unit)
 		let "res_count=${res_count}+1"
-		value_sum=`echo "${cnv_val}+${value_sum}" | bc -l`
+		value_sum=`echo "${cnv_val}+${value_sum}" | bc`
 	done < "${1}.results"
 
 	if [[ $test_name != *"WARNING:"* ]]; then
-		results=$(echo "${value_sum}/${res_count}" | bc -l | cut -d'.' -f1 )
-		sec_results=$(echo "$results/1000000000" | bc -l)
-		printf "%s,%f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
+		results=$(echo "${value_sum}/${res_count}" | bc | cut -d'.' -f1 )
+		sec_results=$(${TOOLS_BIN}/convert_val --time_val --from_unit  ns --to_unit secs --value $results --float --no_unit)
+		printf "%s,%.9f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
 
 		if [[ $to_use_pcp -eq 1 ]]; then
 			metric_name="pyperf_${test_name}"
-			sec_results=$(echo "$results/1000000000" | bc -l)
 			result2pcp "$metric_name" "${sec_results}"
 		fi
 	fi

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -207,6 +207,9 @@ generate_csv_file()
 			if [[ $reduce -eq 2 ]]; then
 				if [[ $test_name != *"WARNING:"* ]]; then
 					results=$(echo "${value_sum}/${res_count}" | bc)
+					#
+					# Timings is in seconds
+					#
 					sec_results=$(${TOOLS_BIN}/convert_val --time_val --from_unit  ns --to_unit secs --value $results --float --no_unit)
 					printf "%s,%.9f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
 					
@@ -234,6 +237,9 @@ generate_csv_file()
 
 	if [[ $test_name != *"WARNING:"* ]]; then
 		results=$(echo "${value_sum}/${res_count}" | bc | cut -d'.' -f1 )
+		#
+		# Timings is in seconds
+		#
 		sec_results=$(${TOOLS_BIN}/convert_val --time_val --from_unit  ns --to_unit secs --value $results --float --no_unit)
 		printf "%s,%.9f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
 

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -190,7 +190,8 @@ generate_csv_file()
 	start_time=$2
 	end_time=$3
 
-  $TOOLS_BIN/test_header_info --front_matter --results_file "${1}.csv" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version "py${PYTHON_VERSION}_$PYPERF_VERSION" --test_name $test_name_run --field_header "Test,Avg,Unit"
+	$TOOLS_BIN/test_header_info --front_matter --results_file "${1}.csv" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version "py${PYTHON_VERSION}_$PYPERF_VERSION" --test_name $test_name_run --field_header "Test,Avg,Unit"
+
 
 	while IFS= read -r line
 	do
@@ -198,18 +199,23 @@ generate_csv_file()
 			test_name=$line
 			continue
 		fi
+		if [[ $line == *"Try to rerun "* ]]; then
+			continue
+		fi
 		if [ -z "$line" ]; then
 			let "reduce=$reduce+1"
 			if [[ $reduce -eq 2 ]]; then
 				if [[ $test_name != *"WARNING:"* ]]; then
-					results=`echo "${value_sum}/${res_count}" | bc -l`
-					printf "%s,%.2f,%s,%s,%s\n" $test_name $results $unit $start_time $end_time >> ${1}.csv
+					results=$(echo "${value_sum}/${res_count}" | bc -l | cut -d'.' -f1 )
+					printf "%s,%d,ns,%s,%s\n" $test_name $results $start_time $end_time >> ${1}.csv
 					
 					if [[ $to_use_pcp -eq 1 ]]; then
 						metric_name="pyperf_${test_name}"
-						ns_results=$($TOOLS_BIN/convert_val --from_unit $unit --to_unit ns --time_val --value $results | sed -e 's/ns//g')
+						#
+						# We are ns already.
+						#
 						# Cannot use convert_val directly since it does not support floating point output
-						sec_results=$(echo "$ns_results/1000000000" | bc -l)
+						sec_results=$(echo "$results/1000000000" | bc -l)
 						result2pcp "$metric_name" "${sec_results}"
 					fi
 				fi
@@ -225,19 +231,19 @@ generate_csv_file()
 		fi
 		value=`echo $line | cut -d' ' -f 4`
 		unit=`echo $line | cut -d' ' -f 5`
+		cnv_val=$($TOOLS_BIN/convert_val --time_val --from_unit  $unit --to_unit ns --value $value | sed "s/ns//g")
 		let "res_count=${res_count}+1"
-		value_sum=`echo "${value}+${value_sum}" | bc -l`
+		value_sum=`echo "${cnv_val}+${value_sum}" | bc -l`
 	done < "${1}.results"
 
 	if [[ $test_name != *"WARNING:"* ]]; then
-		results=`echo "${value_sum}/${res_count}" | bc -l`
-		printf "%s,%.2f,%s,%s,%s\n" $test_name $results $unit $start_time $end_time >> ${1}.csv
+		results=$(echo "${value_sum}/${res_count}" | bc -l | cut -d'.' -f1 )
+		printf "%s,%d,ns,%s,%s\n" $test_name $results $start_time $end_time >> ${1}.csv
 
 		if [[ $to_use_pcp -eq 1 ]]; then
 			metric_name="pyperf_${test_name}"
-			ns_results=$($TOOLS_BIN/convert_val --from_unit $unit --to_unit ns --time_val --value $results | sed -e 's/ns//g')
-			# Cannot use convert_val directly since it does not support floating point output
-			sec_results=$(echo "$ns_results/1000000000" | bc -l)
+			sec_results=$(echo "$results/1000000000" | bc -l)
+			result2pcp "$metric_name" "${sec_results}"
 			result2pcp "$metric_name" "${sec_results}"
 		fi
 	fi

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -244,7 +244,6 @@ generate_csv_file()
 			metric_name="pyperf_${test_name}"
 			sec_results=$(echo "$results/1000000000" | bc -l)
 			result2pcp "$metric_name" "${sec_results}"
-			result2pcp "$metric_name" "${sec_results}"
 		fi
 	fi
 }

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -206,16 +206,13 @@ generate_csv_file()
 			let "reduce=$reduce+1"
 			if [[ $reduce -eq 2 ]]; then
 				if [[ $test_name != *"WARNING:"* ]]; then
+					# Cannot use convert_val directly since it does not support floating point output
 					results=$(echo "${value_sum}/${res_count}" | bc -l | cut -d'.' -f1 )
-					printf "%s,%d,ns,%s,%s\n" $test_name $results $start_time $end_time >> ${1}.csv
+					sec_results=$(echo "$results/1000000000" | bc -l)
+					printf "%s,%f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
 					
 					if [[ $to_use_pcp -eq 1 ]]; then
 						metric_name="pyperf_${test_name}"
-						#
-						# We are ns already.
-						#
-						# Cannot use convert_val directly since it does not support floating point output
-						sec_results=$(echo "$results/1000000000" | bc -l)
 						result2pcp "$metric_name" "${sec_results}"
 					fi
 				fi
@@ -238,7 +235,8 @@ generate_csv_file()
 
 	if [[ $test_name != *"WARNING:"* ]]; then
 		results=$(echo "${value_sum}/${res_count}" | bc -l | cut -d'.' -f1 )
-		printf "%s,%d,ns,%s,%s\n" $test_name $results $start_time $end_time >> ${1}.csv
+		sec_results=$(echo "$results/1000000000" | bc -l)
+		printf "%s,%f,sec,%s,%s\n" $test_name $sec_results $start_time $end_time >> ${1}.csv
 
 		if [[ $to_use_pcp -eq 1 ]]; then
 			metric_name="pyperf_${test_name}"


### PR DESCRIPTION
There is an issue with the time units. The unit may switch from run to run of each subtest (if we are at the boundary). This will cause erroneous reporting of data and averaging. To remedy this, convert the time run for each subtest pass to be nanoseconds.

# Description
Fixes the results so they are always in ns.

# Before/After Comparison
Before: We could get a mix of units when summing up results.  Last unit is what gets reported
After: Results are now reported in ns.

# Clerical Stuff
This closes #71 

Relates to JIRA: RPOPC-947

Testing: 
Ran and verified the output is what we expect.

csv portion
Test,Avg,Unit,Start_Date,End_Date
2to3,247483333,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_generators,316516666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_none,393866666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_cpu_io_mixed,613350000,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_cpu_io_mixed_tg,618100000,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager,98886666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager_cpu_io_mixed,365216666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager_cpu_io_mixed_tg,521300000,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager_io,1070666666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager_io_tg,1036133333,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager_memoization,234616666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager_memoization_tg,378816666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_eager_tg,270533333,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_io,942900000,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
async_tree_io_tg,954366666,ns,2026-04-23T14:45:49Z,2026-04-23T15:38:33Z
