### PR TITLE
fix: Verify $python_exec exists before running

### DIFF
--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -400,9 +400,6 @@ PYTHON_VERSION=$($python_exec --version | awk '{ print $2 }')
 if [[ ${python_pkgs} != "" ]]; then
 	pkg_list="--packages `echo $python_pkgs | sed "s/,/ /g"`"
 fi
-if ! command -v $python_exec; then
-	exit_out "Error: Designated python executable, $python_exec, not present" $E_GENERAL
-fi
 
 if [[  $to_no_pkg_install -eq 0 ]]; then
 	python_bin_name=$(basename $python_exec)

--- a/pyperf/pyperf_run
+++ b/pyperf/pyperf_run
@@ -392,6 +392,10 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
+if ! command -v "$python_exec" > /dev/null; then
+	exit_out "Error: $python_exec either doesn't exist or is not executable!" $E_GENERAL
+fi
+
 PYTHON_VERSION=$($python_exec --version | awk '{ print $2 }')
 if [[ ${python_pkgs} != "" ]]; then
 	pkg_list="--packages `echo $python_pkgs | sed "s/,/ /g"`"


### PR DESCRIPTION
# Description
Verifies that $python_exec is a valid PATH binary or absolute path before running.

# Before/After Comparison
## Before
No verification is done

## After
Wrapper exits out if the executable isn't in the PATH or the absolute file isn't executable.

# Clerical Stuff
Closes #57 

Relates to JIRA: RPOPC-764
